### PR TITLE
Report tinytuya errors in the logs correctly

### DIFF
--- a/lutronbond/tuya.py
+++ b/lutronbond/tuya.py
@@ -15,7 +15,7 @@ ACTIONS = {
 }
 
 
-def get_handler(
+def get_handler(  # noqa: C901
         configmap: dict
 ) -> typing.Callable[[lutron.LutronEvent], typing.Awaitable[bool]]:
 
@@ -60,15 +60,25 @@ def get_handler(
         method = getattr(device, method_name)
 
         def do_action() -> bool:
-            method()
-            logger.info(
-                '%s request sent to Tuya device %s (%s)',
-                action,
-                configmap['id'],
-                configmap.get('name', 'Unnamed')
-            )
+            result = method()
+            if 'Error' in result:
+                logger.error(
+                    '%s request to Tuya device %s (%s) failed: %s',
+                    action,
+                    configmap['id'],
+                    configmap.get('name', 'Unnamed'),
+                    result['Error']
+                )
+                return False
+            else:
+                logger.info(
+                    '%s request sent to Tuya device %s (%s)',
+                    action,
+                    configmap['id'],
+                    configmap.get('name', 'Unnamed')
+                )
 
-            return True
+                return True
 
         logger.debug(
             'Starting %s request to Tuya device %s',

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -129,7 +129,7 @@ def mock_device(mocker):
 
 
 @pytest.mark.asyncio
-async def test_handler__turn_on(
+async def test_handler__turn_on__success(
         mocker,
         lutron_event,
         logger,
@@ -161,6 +161,48 @@ async def test_handler__turn_on(
         'Unnamed'
     )
     assert result is True
+
+
+@pytest.mark.asyncio
+async def test_handler__turn_on__failure(
+        mocker,
+        lutron_event,
+        logger,
+        mock_device):
+    handler = tuya.get_handler({
+        'id': 'asdf',
+        'addr': '10.0.0.2',
+        'key': 'ghjk',
+        'version': 3.3,
+        'actions': {
+            'UNKNOWN': {
+                'UNKNOWN': 'TurnOn'
+            }
+        }
+    })
+
+    mock_device.turn_on.return_value = {
+        'Error': 'Network Error: Device Unreachable',
+        'Err': '905',
+        'Payload': None
+    }
+
+    result = await handler(lutron_event)
+
+    logger.debug.assert_called_with(
+        'Starting %s request to Tuya device %s',
+        'TurnOn',
+        'asdf'
+    )
+    assert mock_device.turn_on.called
+    logger.error.assert_called_with(
+        '%s request to Tuya device %s (%s) failed: %s',
+        'TurnOn',
+        'asdf',
+        'Unnamed',
+        'Network Error: Device Unreachable'
+    )
+    assert result is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When `tinytuya` encounters an error, it returns the error as a response dict. This change inspects the response to determine if an error was encountered, and reports it in the logs. Previously, these errors were swallowed, and success was reported in the logs.