### PR TITLE
Support OUTPUT commands

### DIFF
--- a/lutronbond/config.py
+++ b/lutronbond/config.py
@@ -119,6 +119,15 @@ SMART_SWITCH_ACTIONS = {
     },
 }
 
+SMART_SWITCH_OUTPUT_ACTIONS = {
+    'ANY': {
+        'SET_LEVEL': {
+            '100.00': 'TurnOn',
+            '0.00': 'TurnOff',
+        }
+    }
+}
+
 LUTRON_MAPPING: Dict[int, Dict] = {
     # Lutron Integration ID->Bond/Tuya Device
     21: {
@@ -183,6 +192,28 @@ LUTRON_MAPPING: Dict[int, Dict] = {
             'name': 'Guest Room Fan Light',
             'id': BOND_IDS['Guest Room'],
             'actions': FAN_LIGHT_CONFIG,
+        }
+    },
+    53: {
+        'name': 'Ada Bedroom Main Lights',
+        'tuya': {
+            'name': 'Ada Bedroom Butterfly Light',
+            'id': 'eb92905167786963c1nlkc',
+            'key': 't(cD_7>a$5LA(8}m',
+            'addr': '192.168.1.138',
+            'version': 3.3,
+            'actions': SMART_SWITCH_OUTPUT_ACTIONS,
+        }
+    },
+    50: {
+        'name': 'Hayes Bedroom Main Lights',
+        'tuya': {
+            'name': 'Hayes Bedroom Cloud Light',
+            'id': 'eb0e8441252f2f6d2bppsu',
+            'key': '$$/</w7Q+cQ}#Mt1',
+            'addr': '192.168.1.50',
+            'version': 3.3,
+            'actions': SMART_SWITCH_OUTPUT_ACTIONS,
         }
     },
 }

--- a/lutronbond/controller.py
+++ b/lutronbond/controller.py
@@ -10,13 +10,16 @@ from . import lutron
 from . import tuya
 
 
-EVENT_OPERATION: lutron.Operation = lutron.Operation.DEVICE
+EVENT_OPERATION: list[lutron.Operation] = [
+    lutron.Operation.DEVICE,
+    lutron.Operation.OUTPUT,
+]
 
 logger = logging.getLogger(__name__)
 
 
 def handler(lutron_event: lutron.LutronEvent) -> None:
-    if lutron_event.operation != EVENT_OPERATION:
+    if lutron_event.operation not in EVENT_OPERATION:
         logger.debug('Skipping Lutron event: %s', lutron_event)
         return
 

--- a/lutronbond/tuya.py
+++ b/lutronbond/tuya.py
@@ -15,6 +15,14 @@ ACTIONS = {
 }
 
 
+def is_output_event(event: lutron.LutronEvent) -> bool:
+    return (
+        event.operation.name == "OUTPUT" and
+        event.component.name == "ANY" and
+        event.action.name == "SET_LEVEL"
+    )
+
+
 def get_handler(  # noqa: C901
         configmap: dict
 ) -> typing.Callable[[lutron.LutronEvent], typing.Awaitable[bool]]:
@@ -50,6 +58,13 @@ def get_handler(  # noqa: C901
 
         if action is None:
             return False
+
+        if is_output_event(event):
+            try:
+                action = action[event.parameters]
+            except KeyError:
+                logger.warning('Unknown action: %s:%s', event.component.name, event.parameters)
+                return False
 
         try:
             method_name = ACTIONS[action]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 exclude = .git,__pycache__,venv
 max-complexity = 12
-max-line-length = 90
+max-line-length = 100
 
 [mypy]
 disallow_untyped_defs = True

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -39,7 +39,8 @@ def test__handler__invalid_operation(import_config, logger):
         lutron.Operation.UNKNOWN,
         99,
         lutron.Component.BTN_1,
-        lutron.Action.ENABLE,
+        lutron.DeviceAction.ENABLE,
+        "",
         config.LUTRON_BRIDGE_ADDR
     )
 
@@ -48,13 +49,31 @@ def test__handler__invalid_operation(import_config, logger):
     logger.debug.assert_called_with('Skipping Lutron event: %s', event)
 
 
-def test__handler__valid_operation(import_config, logger, bus):
+def test__handler__valid_operation__DEVICE(import_config, logger, bus):
     config = import_config()
     event = lutron.LutronEvent(
         lutron.Operation.DEVICE,
         99,
         lutron.Component.BTN_1,
-        lutron.Action.PRESS,
+        lutron.DeviceAction.PRESS,
+        "",
+        config.LUTRON_BRIDGE_ADDR
+    )
+
+    controller.handler(event)
+
+    logger.info.assert_called_with('Handling Lutron event: %s', event)
+    bus.pub.assert_called_with('{}:{}'.format(config.LUTRON_BRIDGE_ADDR, 99), event)
+
+
+def test__handler__valid_operation__OUTPUT(import_config, logger, bus):
+    config = import_config()
+    event = lutron.LutronEvent(
+        lutron.Operation.OUTPUT,
+        99,
+        lutron.Component.ANY,
+        lutron.OutputAction.SET_LEVEL,
+        "100.00",
         config.LUTRON_BRIDGE_ADDR
     )
 

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -9,7 +9,20 @@ def lutron_event():
         lutron.Operation.UNKNOWN,
         99,
         lutron.Component.UNKNOWN,
-        lutron.Action.UNKNOWN,
+        lutron.DeviceAction.UNKNOWN,
+        '',
+        '10.0.0.1'
+    )
+
+
+@pytest.fixture()
+def lutron_output_event():
+    return lutron.LutronEvent(
+        lutron.Operation.OUTPUT,
+        99,
+        lutron.Component.ANY,
+        lutron.OutputAction.SET_LEVEL,
+        '100.00',
         '10.0.0.1'
     )
 
@@ -129,7 +142,7 @@ def mock_device(mocker):
 
 
 @pytest.mark.asyncio
-async def test_handler__turn_on__success(
+async def test_handler__turn_on__success__DEVICE(
         mocker,
         lutron_event,
         logger,
@@ -147,6 +160,44 @@ async def test_handler__turn_on__success(
     })
 
     result = await handler(lutron_event)
+
+    logger.debug.assert_called_with(
+        'Starting %s request to Tuya device %s',
+        'TurnOn',
+        'asdf'
+    )
+    assert mock_device.turn_on.called
+    logger.info.assert_called_with(
+        '%s request sent to Tuya device %s (%s)',
+        'TurnOn',
+        'asdf',
+        'Unnamed'
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_handler__turn_on__success__OUTPUT(
+        mocker,
+        lutron_output_event,
+        logger,
+        mock_device):
+    handler = tuya.get_handler({
+        'id': 'asdf',
+        'addr': '10.0.0.2',
+        'key': 'ghjk',
+        'version': 3.3,
+        'actions': {
+            'ANY': {
+                'SET_LEVEL': {
+                    '100.00': 'TurnOn',
+                    '0.00': 'TurnOff',
+                }
+            }
+        }
+    })
+
+    result = await handler(lutron_output_event)
 
     logger.debug.assert_called_with(
         'Starting %s request to Tuya device %s',
@@ -206,7 +257,7 @@ async def test_handler__turn_on__failure(
 
 
 @pytest.mark.asyncio
-async def test_handler__turn_off(
+async def test_handler__turn_off__DEVICE(
         mocker,
         lutron_event,
         logger,
@@ -224,6 +275,46 @@ async def test_handler__turn_off(
     })
 
     result = await handler(lutron_event)
+
+    logger.debug.assert_called_with(
+        'Starting %s request to Tuya device %s',
+        'TurnOff',
+        'asdf'
+    )
+    assert mock_device.turn_off.called
+    logger.info.assert_called_with(
+        '%s request sent to Tuya device %s (%s)',
+        'TurnOff',
+        'asdf',
+        'Unnamed'
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_handler__turn_off__OUTPUT(
+        mocker,
+        lutron_output_event,
+        logger,
+        mock_device):
+    handler = tuya.get_handler({
+        'id': 'asdf',
+        'addr': '10.0.0.2',
+        'key': 'ghjk',
+        'version': 3.3,
+        'actions': {
+            'ANY': {
+                'SET_LEVEL': {
+                    '100.00': 'TurnOn',
+                    '0.00': 'TurnOff',
+                }
+            }
+        }
+    })
+
+    lutron_output_event.parameters = '0.00'
+
+    result = await handler(lutron_output_event)
 
     logger.debug.assert_called_with(
         'Starting %s request to Tuya device %s',


### PR DESCRIPTION
Allow Lutron `OUTPUT` commands to trigger actions.

Pico remotes generate `DEVICE` commands, but hardwired devices (like light switches) generate OUTPUT commands. This change allows these devices to trigger actions based on the level of the output command.

For example, this allows turning off a Tuya smart switch when a hardwired light is turned off. Or, it can turn on a fan light when the hardwired lights in a room are also turned on.