### PR TITLE
Support Lutron Commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,9 @@ dmypy.json
 
 # macOS
 .DS_Store
+
+#tinytuya
+devices.json
+snapshot.json
+tinytuya.json
+tuya-raw.json

--- a/lutronbond/config.py
+++ b/lutronbond/config.py
@@ -219,7 +219,36 @@ LUTRON_MAPPING: Dict[int, Dict] = {
     },
     60: {
         'name': 'Hayes Cloud Light Pico',
-        'tuya': dict(HAYES_CLOUD_LIGHT, actions=SMART_SWITCH_ACTIONS)
+        'tuya': dict(HAYES_CLOUD_LIGHT, actions=SMART_SWITCH_ACTIONS),
+        'lutron': {
+            'name': 'Hayes Bedroom Main Lights',
+            'bridge': 1,
+            'id': 50,
+            'actions': {
+                'BTN_RAISE': {
+                    'PRESS': None,
+                    'RELEASE': {
+                        'SET_LEVEL': '100,00.50',
+                        # In English:
+                        #   when integration ID 60's BTN_RAISE is released,
+                        #   set the output level of integration ID 50 to
+                        #   100 with a transition duration of half a second.
+                    },
+                },
+                'BTN_LOWER': {
+                    'PRESS': None,
+                    'RELEASE': {
+                        'SET_LEVEL': '0,01',
+                    },
+                },
+                'BTN_2': {
+                    'PRESS': None,
+                    'RELEASE': {
+                        'SET_LEVEL': '38,01',
+                    }
+                },
+            }
+        }
     },
 }
 

--- a/lutronbond/controller.py
+++ b/lutronbond/controller.py
@@ -54,6 +54,13 @@ def add_listeners_for_bridge(bridge_addr: str, config_map: typing.Dict) -> None:
             else:
                 eventbus.get_bus().sub(key, tuya.get_handler(subconfig['tuya']))
 
+        if 'lutron' in subconfig:
+            if type(subconfig['lutron']) is list:
+                for config_item in subconfig['lutron']:
+                    eventbus.get_bus().sub(key, lutron.get_handler(config_item))
+            else:
+                eventbus.get_bus().sub(key, lutron.get_handler(subconfig['lutron']))
+
 
 def add_listeners() -> None:
     add_listeners_for_bridge(config.LUTRON_BRIDGE_ADDR, config.LUTRON_MAPPING)

--- a/tests/test_bond.py
+++ b/tests/test_bond.py
@@ -118,6 +118,8 @@ async def test_handler__none_action(lutron_event, logger):
 
     assert result is False
 
+    assert not logger.warning.called
+
 
 @pytest.fixture
 def mock_bond_action(mocker):


### PR DESCRIPTION
Allow events to trigger commands that are sent back to the Lutron bridge. This allows a few interesting use cases:

1. Events from one Lutron bridge may trigger actions on the second bridge (or vise versa).
2. OUTPUT events from one Lutron device may trigger actions on other Lutron devices. For example, this would allow an in-wall switch to control (in addition to itself) a totally different light (or lights), somewhat like a Pico remote.
3. Arbitrary buttons on Pico remotes could trigger arbitrary actions on other Lutron devices. For example, the RAISE and LOWER buttons could actually control the ON/OFF state of an unrelated switch, instead of dimming the same switch.